### PR TITLE
Azure Event Hub Receiver: Fix build errors from lint, go mod and add …

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -155,6 +155,7 @@ pkg/sampling/                                                       @open-teleme
 pkg/stanza/                                                         @open-telemetry/collector-contrib-approvers @djaglowski
 pkg/stanza/fileconsumer/                                            @open-telemetry/collector-contrib-approvers @djaglowski
 pkg/translator/azure/                                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins
+pkg/translator/azure_log/                                           @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins
 pkg/translator/jaeger/                                              @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @frzifus
 pkg/translator/loki/                                                @open-telemetry/collector-contrib-approvers @gouthamve @jpkrohling @mar4uk
 pkg/translator/opencensus/                                          @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -1354,3 +1354,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otela
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver => ../../extension/observer/cfgardenobserver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter => ../../exporter/rabbitmqexporter
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure_logs => ../../pkg/translator/azure_logs

--- a/receiver/azureeventhubreceiver/azureresourcelogs_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/azureresourcelogs_unmarshaler.go
@@ -30,14 +30,15 @@ func newAzureResourceLogsUnmarshaler(buildInfo component.BuildInfo, logger *zap.
 				Logger:  logger,
 			},
 		}
-	} else {
-		return AzureResourceLogsEventUnmarshaler{
-			unmarshaler: &azure.ResourceLogsUnmarshaler{
-				Version: buildInfo.Version,
-				Logger:  logger,
-			},
-		}
 	}
+
+	return AzureResourceLogsEventUnmarshaler{
+		unmarshaler: &azure.ResourceLogsUnmarshaler{
+			Version: buildInfo.Version,
+			Logger:  logger,
+		},
+	}
+
 }
 
 // UnmarshalLogs takes a byte array containing a JSON-encoded


### PR DESCRIPTION
Ran make gotidy and make crosslink and fixed an error identified by make lint and added a Code Owners block for the new component pkg/translator/azure_logs.